### PR TITLE
chore(database): configure database settings

### DIFF
--- a/backend/porkin/src/main/resources/application.properties
+++ b/backend/porkin/src/main/resources/application.properties
@@ -1,1 +1,9 @@
 spring.application.name=porkin
+
+spring.datasource.url=jdbc:postgresql://localhost:5432
+spring.datasource.username=postgres
+spring.datasource.password=12122002
+
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=true


### PR DESCRIPTION
This pull request configures the PostgreSQL database settings in the application.properties file. The following properties were added:

    spring.datasource.url=jdbc:postgresql://localhost:5432
    spring.datasource.username=postgres
    spring.datasource.password=12122002
    spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
    spring.jpa.hibernate.ddl-auto=create-drop
    spring.jpa.show-sql=true

These changes establish the connection to a local PostgreSQL database, set the dialect for Hibernate, and enable SQL logging for debugging purposes.